### PR TITLE
fix inheritance when first row is header

### DIFF
--- a/lib/command_line_reporter/table.rb
+++ b/lib/command_line_reporter/table.rb
@@ -114,7 +114,7 @@ module CommandLineReporter
         # keep default
       elsif row.color
         c.color = row.color
-			elsif self.rows.size > inherit_from
+      elsif self.rows.size > inherit_from
         c.color = self.rows[inherit_from].columns[i].color
       end
     end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -35,21 +35,21 @@ describe CommandLineReporter::Table do
       }.to_not raise_error
     end
 
-		context 'inherits' do
-			before :each do
-				@cols1 = [
-					CommandLineReporter::Column.new('asdf', :width => 5),
-					CommandLineReporter::Column.new('qwer', :align => 'right', :color => 'purple'),
-					CommandLineReporter::Column.new('tutu', :color => 'green'),
-					CommandLineReporter::Column.new('uiui', :bold => true),
-				]
-				@cols2 = [
-					CommandLineReporter::Column.new('test'),
-					CommandLineReporter::Column.new('test'),
-					CommandLineReporter::Column.new('test', :color => 'blue'),
-					CommandLineReporter::Column.new('test'),
-				]
-			end
+    context 'inherits' do
+      before :each do
+        @cols1 = [
+          CommandLineReporter::Column.new('asdf', :width => 5),
+          CommandLineReporter::Column.new('qwer', :align => 'right', :color => 'purple'),
+          CommandLineReporter::Column.new('tutu', :color => 'green'),
+          CommandLineReporter::Column.new('uiui', :bold => true),
+        ]
+        @cols2 = [
+          CommandLineReporter::Column.new('test'),
+          CommandLineReporter::Column.new('test'),
+          CommandLineReporter::Column.new('test', :color => 'blue'),
+          CommandLineReporter::Column.new('test'),
+        ]
+      end
 
       context 'no header row' do
         before :each do
@@ -60,21 +60,21 @@ describe CommandLineReporter::Table do
           row = CommandLineReporter::Row.new
           @cols2.each {|c| row.add(c)}
           @table.add(row)
-				end
+        end
 
-				it 'positional attributes' do
-					[:align, :width, :size, :padding].each do |m|
-						4.times do |i|
-							expect(@table.rows[1].columns[i].send(m)).to eq(@table.rows[0].columns[i].send(m))
-						end
-					end
-				end
+        it 'positional attributes' do
+          [:align, :width, :size, :padding].each do |m|
+            4.times do |i|
+              expect(@table.rows[1].columns[i].send(m)).to eq(@table.rows[0].columns[i].send(m))
+            end
+          end
+        end
 
-				it 'color' do
-					expect(@table.rows[1].columns[0].color).to eq(@table.rows[0].columns[0].color)
-					expect(@table.rows[1].columns[1].color).to eq(@table.rows[0].columns[1].color)
+        it 'color' do
+          expect(@table.rows[1].columns[0].color).to eq(@table.rows[0].columns[0].color)
+          expect(@table.rows[1].columns[1].color).to eq(@table.rows[0].columns[1].color)
           expect(@table.rows[1].columns[2].color).to eq('blue')
-					expect(@table.rows[1].columns[3].color).to eq(@table.rows[0].columns[3].color)
+          expect(@table.rows[1].columns[3].color).to eq(@table.rows[0].columns[3].color)
         end
 
         it 'bold' do


### PR DESCRIPTION
#### Error message when first row is header:

```
 ../gems/command_line_reporter-3.3.1/lib/command_line_reporter/table.rb:118:in `use_color': undefined method `columns' for nil:NilClass (NoMethodError)
```
#### All tests were green, thus `spec/table_spec.rb` was checked and fixed first:
- Context setups are reorganized, because columns are changed when they used for table creation, this way the header test was not correct
- No header color test are changed to compare to columns of first row, except where color is overridden
- With header row none of the columns should be bold in the second row
#### Based on new tests `lib/command_line_reporter/table.rb` is fixed:

The following condition allow access 'inherit_from' row if it exists

``` ruby
if self.rows.size > inherit_from
```
