### PR TITLE
Fix for Newrelic_rpm incompatibility

### DIFF
--- a/lib/command_line_reporter.rb
+++ b/lib/command_line_reporter.rb
@@ -36,7 +36,7 @@ module CommandLineReporter
   end
 
   def formatter=(type = 'nested')
-    return type if type.class != String
+    return (@formatter = type) if type.class != String
     name = type.capitalize + 'Formatter'
     klass = %W{CommandLineReporter #{name}}.inject(Kernel) {|s,c| s.const_get(c)}
 

--- a/lib/command_line_reporter.rb
+++ b/lib/command_line_reporter.rb
@@ -36,6 +36,7 @@ module CommandLineReporter
   end
 
   def formatter=(type = 'nested')
+    return type if type.class != String
     name = type.capitalize + 'Formatter'
     klass = %W{CommandLineReporter #{name}}.inject(Kernel) {|s,c| s.const_get(c)}
 

--- a/spec/command_line_reporter_spec.rb
+++ b/spec/command_line_reporter_spec.rb
@@ -41,7 +41,7 @@ describe CommandLineReporter do
     it 'returns the type if the parameter is something other than a String' do
       fmt = Proc.new{}
       subject.formatter = Proc.new{}
-      expect(subject.formatter.class).to eq(fmt)
+      expect(subject.formatter).to eq(fmt)
     end
   end
 

--- a/spec/command_line_reporter_spec.rb
+++ b/spec/command_line_reporter_spec.rb
@@ -37,6 +37,12 @@ describe CommandLineReporter do
       subject.formatter = 'nested'
       expect(subject.formatter.class).to eq(CommandLineReporter::NestedFormatter)
     end
+    
+    it 'returns the type if the parameter is something other than a String' do
+      fmt = Proc.new{}
+      subject.formatter = Proc.new{}
+      expect(subject.formatter.class).to eq(fmt)
+    end
   end
 
   describe '#report' do

--- a/spec/command_line_reporter_spec.rb
+++ b/spec/command_line_reporter_spec.rb
@@ -38,11 +38,16 @@ describe CommandLineReporter do
       expect(subject.formatter.class).to eq(CommandLineReporter::NestedFormatter)
     end
     
-    it 'returns the type if the parameter is something other than a String' do
-      fmt = Proc.new{}
-      subject.formatter = Proc.new{}
-      expect(subject.formatter).to eq(fmt)
+    it "doesn't fail if the type parameter is a Proc" do
+      subject.formatter = Proc.new { }
+      expect(subject.formatter).to_not raise_exception
     end
+
+    it "returns the type if the parameter is something other than a String" do
+      subject.formatter = Proc.new { }
+      expect(subject.formatter.class).to eq(Proc)
+    end
+
   end
 
   describe '#report' do

--- a/spec/command_line_reporter_spec.rb
+++ b/spec/command_line_reporter_spec.rb
@@ -37,7 +37,7 @@ describe CommandLineReporter do
       subject.formatter = 'nested'
       expect(subject.formatter.class).to eq(CommandLineReporter::NestedFormatter)
     end
-    
+
     it "doesn't fail if the type parameter is a Proc" do
       subject.formatter = Proc.new { }
       expect(subject.formatter).to_not raise_exception


### PR DESCRIPTION
Rake tasks with newrelic_rpm in the gemset fail because newrelic sets formatter= to a Proc. This is a quick fix to pass through format types that aren't Strings.