### PR TITLE
Revert changes for coloured table borders

### DIFF
--- a/lib/command_line_reporter/row.rb
+++ b/lib/command_line_reporter/row.rb
@@ -2,7 +2,7 @@ module CommandLineReporter
   class Row
     include OptionsValidator
 
-    VALID_OPTIONS = [:header, :color, :border_color, :bold, :encoding]
+    VALID_OPTIONS = [:header, :color, :bold, :encoding]
     attr_accessor :columns, :border, *VALID_OPTIONS
 
     def initialize(options = {})
@@ -12,7 +12,6 @@ module CommandLineReporter
       self.border = false
       self.header = options[:header] || false
       self.color = options[:color]
-      self.border_color = options[:border_color]
       self.bold = options[:bold] || false
       self.encoding = options[:encoding] || :unicode
     end
@@ -32,7 +31,6 @@ module CommandLineReporter
     def output
       screen_count.times do |sr|
         border_char = use_utf8? ? "\u2503" : '|'
-        border_char = border_char.send(self.border_color) if self.border_color
 
         line = (self.border) ? "#{border_char} " : ''
 

--- a/lib/command_line_reporter/table.rb
+++ b/lib/command_line_reporter/table.rb
@@ -2,14 +2,13 @@ module CommandLineReporter
   class Table
     include OptionsValidator
 
-    VALID_OPTIONS = [:border, :border_color, :width, :encoding]
+    VALID_OPTIONS = [:border, :width, :encoding]
     attr_accessor :rows, *VALID_OPTIONS
 
     def initialize(options = {})
       self.validate_options(options, *VALID_OPTIONS)
 
       self.border = options[:border] || false
-      self.border_color = options[:border_color] || false
       self.width = options[:width] || false
       self.encoding = options[:encoding] || CommandLineReporter::DEFAULTS[:encoding]
 
@@ -21,7 +20,6 @@ module CommandLineReporter
     def add(row)
       # Inheritance from the table
       row.border = self.border
-      row.border_color = self.border_color
 
       # Inherit properties from the appropriate row
       inherit_column_attrs(row) if self.rows[0]
@@ -62,8 +60,7 @@ module CommandLineReporter
     def separator(type = 'middle')
       left, center, right, bar = use_utf8? ? utf8_separator(type) : ascii_separator
 
-      separator_str = left + self.rows[0].columns.map {|c| bar * (c.width + 2)}.join(center) + right
-      separator_str.send(self.border_color) if self.border_color
+      left + self.rows[0].columns.map {|c| bar * (c.width + 2)}.join(center) + right
     end
 
     def use_utf8?

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -16,14 +16,6 @@ describe CommandLineReporter::Table do
       expect(CommandLineReporter::Table.new(:border => true).border).to eq(true)
     end
 
-    it 'defaults the border_color' do
-      expect(CommandLineReporter::Table.new.border_color).to be false
-    end
-
-    it 'accepts the border_color' do
-      expect(CommandLineReporter::Table.new(:border_color => true).border_color).to eq(true)
-    end
-
     it 'output encoding should be ascii' do
       expect(CommandLineReporter::Table.new(:encoding => :ascii).encoding).to eq(:ascii)
     end
@@ -120,7 +112,6 @@ describe CommandLineReporter::Table do
     end
   end
 
-  
   describe '#auto_adjust_widths' do
     it 'sets the widths of each column in each row to the maximum required width for that column' do
       table = CommandLineReporter::Table.new.tap do |t|


### PR DESCRIPTION
Removes the changes for coloured table borders that were introduced in a59d00e4b77ae61763280708c9263a1955031cf0.
It was easier to remove this feature than to debug the issue.

I believe it's safe to remove this minor feature considering it was only added recently and it wasn't documented anywhere, so it's very unlikely that anyone is using the `border_color` option.

Alternatively, @lastobelus (who authored the changes) might be interested in debugging it.

Note that I did not revert the gem switch, since byebug should still be used instead of debugger.

Fixes #21 