### PR TITLE
Replace colored with ansi and support color codes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source 'http://rubygems.org'
 
+gemspec
+
 gem 'gollum'
 gem 'RedCloth'
 gem 'redcarpet', '1.17.2'
-gem 'colored'
 gem 'reek'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .
+  specs:
+    command_line_reporter (3.3.5)
+      ansi (~> 1.5, >= 1.5.0)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -12,6 +18,7 @@ GEM
     adamantium (0.2.0)
       ice_nine (~> 0.11.0)
       memoizable (~> 0.4.0)
+    ansi (1.5.0)
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
@@ -25,7 +32,6 @@ GEM
       timers (~> 4.0.0)
     charlock_holmes (0.7.3)
     coderay (1.1.0)
-    colored (1.2)
     columnize (0.9.0)
     concord (0.1.5)
       adamantium (~> 0.2.0)
@@ -191,8 +197,9 @@ DEPENDENCIES
   RedCloth
   autotest-growl
   autotest-standalone
+  bundler (>= 1.0.0)
   byebug
-  colored
+  command_line_reporter!
   faraday
   flay
   flog

--- a/command_line_reporter.gemspec
+++ b/command_line_reporter.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
   gem.test_files = Dir['spec/**/*'] & `git ls-files -z`.split("\0")
 
   gem.add_development_dependency "bundler", ">= 1.0.0"
-  gem.add_dependency "colored", ">= 1.2"
+  gem.add_runtime_dependency 'ansi', '~> 1.5', '>= 1.5.0'
 end
 

--- a/lib/command_line_reporter.rb
+++ b/lib/command_line_reporter.rb
@@ -63,7 +63,7 @@ module CommandLineReporter
   end
 
   def horizontal_rule(options = {})
-    validate_options(options, :char, :width, :color, :bold)
+    validate_options(options, :char, :width, :color, :color_code, :bold)
 
     # Got unicode?
     use_char = "\u2501" == 'u2501' ? '-' : "\u2501"
@@ -71,7 +71,7 @@ module CommandLineReporter
     char = options[:char].is_a?(String) ? options[:char] : use_char
     width = options[:width] || DEFAULTS[:width]
 
-    aligned(char * width, :width => width, :color => options[:color], :bold => options[:bold])
+    aligned(char * width, :width => width, :color => options[:color], :color_code => options[:color_code], :bold => options[:bold])
   end
 
   def vertical_spacing(lines = 1)
@@ -86,7 +86,7 @@ module CommandLineReporter
   end
 
   def datetime(options = {})
-    validate_options(options, :align, :width, :format, :color, :bold)
+    validate_options(options, :align, :width, :format, :color, :color_code, :bold)
 
     format = options[:format] || '%Y-%m-%d - %l:%M:%S%p'
     align = options[:align] || DEFAULTS[:align]
@@ -96,15 +96,16 @@ module CommandLineReporter
 
     raise Exception if text.size > width
 
-    aligned(text, :align => align, :width => width, :color => options[:color], :bold => options[:bold])
+    aligned(text, :align => align, :width => width, :color => options[:color], :color_code => options[:color_code], :bold => options[:bold])
   end
 
   def aligned(text, options = {})
-    validate_options(options, :align, :width, :color, :bold)
+    validate_options(options, :align, :width, :color, :color_code, :bold)
 
     align = options[:align] || DEFAULTS[:align]
     width = options[:width] || DEFAULTS[:width]
     color = options[:color]
+    color_code = options[:color_code]
     bold = options[:bold] || false
 
     line = case align
@@ -118,8 +119,9 @@ module CommandLineReporter
              raise ArgumentError
            end
 
-    line = line.send(color) if color
-    line = line.send('bold') if bold
+    line = ANSI.public_send(color) { line } if color
+    line = ANSI::Code.rgb(color_code) { line } if color_code
+    line = ANSI.bold { line } if bold
 
     puts line
   end
@@ -145,35 +147,36 @@ module CommandLineReporter
   private
 
   def section(type, options)
-    title, width, align, lines, color, bold = assign_section_properties(options)
+    title, width, align, lines, color, color_code, bold = assign_section_properties(options)
 
     # This also ensures that width is a Fixnum
     raise ArgumentError if title.size > width
 
     if type == :footer
       vertical_spacing(lines)
-      horizontal_rule(:char => options[:rule], :width => width, :color => color, :bold => bold) if options[:rule]
+      horizontal_rule(:char => options[:rule], :width => width, :color => color, :color_code => color_code, :bold => bold) if options[:rule]
     end
 
     aligned(title, :align => align, :width => width, :color => color, :bold => bold)
-    datetime(:align => align, :width => width, :color => color, :bold => bold) if options[:timestamp]
+    datetime(:align => align, :width => width, :color => color, :color_code => color_code, :bold => bold) if options[:timestamp]
 
     if type == :header
-      horizontal_rule(:char => options[:rule], :width => width, :color => color, :bold => bold) if options[:rule]
+      horizontal_rule(:char => options[:rule], :width => width, :color => color, :color_code => color_code, :bold => bold) if options[:rule]
       vertical_spacing(lines)
     end
   end
 
   def assign_section_properties options
-    validate_options(options, :title, :width, :align, :spacing, :timestamp, :rule, :color, :bold)
+    validate_options(options, :title, :width, :align, :spacing, :timestamp, :rule, :color, :color_code, :bold)
 
     title = options[:title] || 'Report'
     width = options[:width] || DEFAULTS[:width]
     align = options[:align] || DEFAULTS[:align]
     lines = options[:spacing] || 1
     color = options[:color]
+    color_code = options[:color_code]
     bold = options[:bold] || false
 
-    return [title, width, align, lines, color, bold]
+    return [title, width, align, lines, color, color_code, bold]
   end
 end

--- a/lib/command_line_reporter/column.rb
+++ b/lib/command_line_reporter/column.rb
@@ -1,10 +1,10 @@
-require 'colored'
+require 'ansi'
 
 module CommandLineReporter
   class Column
     include OptionsValidator
 
-    VALID_OPTIONS = [:width, :padding, :align, :color, :bold, :underline, :reversed]
+    VALID_OPTIONS = [:width, :padding, :align, :color, :color_code, :bold, :underline, :reversed]
     attr_accessor :text, :size, *VALID_OPTIONS
 
     def initialize(text = nil, options = {})
@@ -16,6 +16,7 @@ module CommandLineReporter
       self.align = options[:align] || 'left'
       self.padding = options[:padding] || 0
       self.color = options[:color] || nil
+      self.color_code = options[:color_code] || nil
       self.bold = options[:bold] || false
       self.underline = options[:underline] || false
       self.reversed = options[:reversed] || false
@@ -67,8 +68,9 @@ module CommandLineReporter
     end
 
     def colorize(str)
-      str = str.send(color) if self.color
-      str = str.send('bold') if self.bold
+      str = ANSI.public_send(color) { str } if self.color
+      str = ANSI::Code.rgb(color_code) { str } if self.color_code
+      str = ANSI.bold { str } if self.bold
       str
     end
   end

--- a/lib/command_line_reporter/formatter/nested.rb
+++ b/lib/command_line_reporter/formatter/nested.rb
@@ -1,13 +1,13 @@
 require 'singleton'
-require 'colored'
+require 'ansi'
 
 module CommandLineReporter
   class NestedFormatter
     include Singleton
     include OptionsValidator
 
-    VALID_OPTIONS = [:message, :type, :complete, :indent_size, :color, :bold]
-    attr_accessor :indent_size, :complete_string, :message_string, :color, :bold
+    VALID_OPTIONS = [:message, :type, :complete, :indent_size, :color, :color_code, :bold]
+    attr_accessor :indent_size, :complete_string, :message_string, :color, :color_code, :bold
 
     def format(options, block)
       self.validate_options(options, *VALID_OPTIONS)
@@ -48,8 +48,9 @@ module CommandLineReporter
     private
 
     def colorize(str, inline, options)
-      str = str.send(options[:color]) if options[:color]
-      str = str.bold if options[:bold]
+      str = ANSI.public_send(options[:color]) { str } if options[:color]
+      str = ANSI::Code.rgb(options[:color_code]) { str } if options[:color_code]
+      str = ANSI.bold { str } if options[:bold]
 
       if inline
         print str

--- a/lib/command_line_reporter/formatter/progress.rb
+++ b/lib/command_line_reporter/formatter/progress.rb
@@ -1,12 +1,12 @@
 require 'singleton'
-require 'colored'
+require 'ansi'
 
 module CommandLineReporter
   class ProgressFormatter
     include Singleton
     include OptionsValidator
 
-    VALID_OPTIONS = [:indicator, :color, :bold]
+    VALID_OPTIONS = [:indicator, :color, :color_code, :bold]
     attr_accessor *VALID_OPTIONS
 
     def format(options, block)
@@ -14,6 +14,7 @@ module CommandLineReporter
 
       self.indicator = options[:indicator] if options[:indicator]
       self.color = options[:color]
+      self.color_code = options[:color_code]
       self.bold = options[:bold] || false
 
       block.call
@@ -24,8 +25,9 @@ module CommandLineReporter
     def progress(override = nil)
       str = override || self.indicator
 
-      str = str.send(self.color) if self.color
-      str = str.send('bold') if self.bold
+      str = ANSI.public_send(color) { str } if self.color
+      str = ANSI::Code.rgb(color_code) { str } if self.color_code
+      str = ANSI.bold { str } if self.bold
 
       print str
     end

--- a/lib/command_line_reporter/row.rb
+++ b/lib/command_line_reporter/row.rb
@@ -2,7 +2,7 @@ module CommandLineReporter
   class Row
     include OptionsValidator
 
-    VALID_OPTIONS = [:header, :color, :bold, :encoding]
+    VALID_OPTIONS = [:header, :color, :color_code, :bold, :encoding]
     attr_accessor :columns, :border, *VALID_OPTIONS
 
     def initialize(options = {})
@@ -12,6 +12,7 @@ module CommandLineReporter
       self.border = false
       self.header = options[:header] || false
       self.color = options[:color]
+      self.color_code = options[:color_code]
       self.bold = options[:bold] || false
       self.encoding = options[:encoding] || :unicode
     end
@@ -19,6 +20,10 @@ module CommandLineReporter
     def add(column)
       if column.color.nil? && self.color
         column.color = self.color
+      end
+
+      if column.color_code.nil? && self.color_code
+        column.color_code = self.color_code
       end
 
       if self.bold || self.header

--- a/lib/command_line_reporter/table.rb
+++ b/lib/command_line_reporter/table.rb
@@ -92,6 +92,7 @@ module CommandLineReporter
       row.columns.each_with_index do |c,i|
         use_positional_attrs(c, i)
         use_color(row, c, i)
+        use_color_code(row, c, i)
         use_bold(row, c, i)
       end
     end
@@ -116,6 +117,16 @@ module CommandLineReporter
         c.color = row.color
       elsif inherit_from != 1
         c.color = self.rows[inherit_from].columns[i].color
+      end
+    end
+
+    def use_color_code(row, c, i)
+      if c.color_code
+        # keep default
+      elsif row.color_code
+        c.color_code = row.color_code
+      elsif inherit_from != 1
+        c.color_code = self.rows[inherit_from].columns[i].color_code
       end
     end
 


### PR DESCRIPTION
Maybe this is coming out of the blue, but I had the need to support more than 3 colors in a table. Ansi gem approximates rgb colors to the colors supported by the terminal. I replaced the colored gem with Ansi and added the `color_code` option. Please review with :heart:

I didn't want to change anything else, but maybe a next step would be to move all color related things to one place. What do you think?
